### PR TITLE
Add negative length check to meta event parsing

### DIFF
--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -171,6 +171,10 @@ midi_parse_meta_event(struct midi_parser *parser)
   int32_t offset   = 2;
   parser->meta.length = midi_parse_variable_length(parser, &offset);
 
+  // length should never be negative
+  if (parser->meta.length < 0)
+    return MIDI_PARSER_ERROR;
+
   // check buffer size
   if (parser->size < offset + parser->meta.length)
     return MIDI_PARSER_EOB;


### PR DESCRIPTION
I managed to find a crash by fuzzing the example. This patch should fix the issue.