### PR TITLE
Bug fixes

### DIFF
--- a/src/midi-dump.c
+++ b/src/midi-dump.c
@@ -46,7 +46,7 @@ static void parse_and_dump(struct midi_parser *parser)
 
     case MIDI_PARSER_TRACK_MIDI:
       puts("track-midi");
-      printf("  time: %d\n", parser->vtime);
+      printf("  time: %ld\n", parser->vtime);
       printf("  status: %d [%s]\n", parser->midi.status, midi_status_name(parser->midi.status));
       printf("  channel: %d\n", parser->midi.channel);
       printf("  param1: %d\n", parser->midi.param1);
@@ -55,14 +55,14 @@ static void parse_and_dump(struct midi_parser *parser)
 
     case MIDI_PARSER_TRACK_META:
       printf("track-meta\n");
-      printf("  time: %d\n", parser->vtime);
+      printf("  time: %ld\n", parser->vtime);
       printf("  type: %d [%s]\n", parser->meta.type, midi_meta_name(parser->meta.type));
       printf("  length: %d\n", parser->meta.length);
       break;
 
     case MIDI_PARSER_TRACK_SYSEX:
       puts("track-sysex");
-      printf("  time: %d\n", parser->vtime);
+      printf("  time: %ld\n", parser->vtime);
       break;
 
     default:

--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -201,6 +201,11 @@ midi_parse_event(struct midi_parser *parser)
   if (!midi_parse_vtime(parser))
     return MIDI_PARSER_EOB;
 
+  // Make sure the parser has not consumed the entire file or track, else
+  // `parser-in[0]` might access heap-memory after the allocated buffer.
+  if (parser->size <= 0 || parser->track.size <= 0)
+    return MIDI_PARSER_ERROR;
+
   if (parser->in[0] < 0xf0)
     return midi_parse_channel_event(parser);
   if (parser->in[0] == 0xff)

--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -174,19 +174,19 @@ midi_parse_meta_event(struct midi_parser *parser)
   assert(parser->in[0] == 0xff);
 
   if (parser->size < 2)
-    return MIDI_PARSER_EOB;
+    return MIDI_PARSER_ERROR;
 
   parser->meta.type = parser->in[1];
   int32_t offset   = 2;
   parser->meta.length = midi_parse_variable_length(parser, &offset);
 
-  // length should never be negative
-  if (parser->meta.length < 0)
+  // length should never be negative or more than the remaining size
+  if (parser->meta.length < 0 || parser->meta.length > parser->size)
     return MIDI_PARSER_ERROR;
 
   // check buffer size
-  if (parser->size < offset + parser->meta.length)
-    return MIDI_PARSER_EOB;
+  if (parser->size < offset || parser->size - offset < parser->meta.length)
+    return MIDI_PARSER_ERROR;
 
   offset += parser->meta.length;
   parser->in += offset;

--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -125,7 +125,7 @@ midi_parse_vtime(struct midi_parser *parser)
   while (cont) {
     ++nbytes;
 
-    if (parser->size < nbytes)
+    if (parser->size < nbytes || parser->track.size < nbytes)
       return false;
 
     uint8_t b = parser->in[nbytes - 1];


### PR DESCRIPTION
I found 4 bugs. The first one is an endless loop and the second one is a heap buffer over-read and the third one is an integer underflow and one integer overflow. I assume they are fixed now. Also, I silenced some compiler warnings.

example input that caused an endless loop:

```
$ xxd timeout-18224650799029ad6f18192bc2d1748d443f6564
00000000: 4d54 6864 ffcf ffef ffff ffff 2aff ff2b  MThd........*..+
00000010: 2b2b ffff ffff ffff ffff ffff ffff ffff  ++..............
00000020: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000030: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000040: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000050: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000060: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000070: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000080: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000090: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000a0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000b0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000c0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000d0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000e0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
000000f0: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000100: ffff ffff ffff ffff ffff ffff ffff ffff  ................
00000110: ffff ffff ffff ffff 0002 0000 22ff       ............".
```

example input to trigger the heap buffer overread:

```
$ xxd crashes/crash-98960fb538124d7093512a0861e02487c5b270a3
00000000: 4d54 6864 ffca caca caca caca caca 2200  MThd..........".
00000010: 0000 0000 0000 0000 0000 2900 0000 0000  ..........).....
00000020: 0000 0000 0000 0000 d3ff 0000 3ac5 16    ............:..
```

example input for integer underflow:
```
$ xxd crash-8d63826784bc5836b04dc8c6027200ba6d5f6100                       
00000000: 4d54 6864 ff4a 8aca ffff ff95 0000 0909  MThd.J..........                                                                                                                              
00000010: 0000 8000 0000 0000 0000 0000 0000 0000  ................                                                                                                                              
00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................                                                                                                                              
00000030: 0000 0000 0000 0009 0909 0909 0000 0400  ................                                                                                                                              
00000040: 00ca 0000 0000 0021 0000                 .......!..   
```

example input for integer overflow:
```
xxd crash-5de12c5194267073120ffce3776656ad65c9df73                                                                                
00000000: 4d54 6864 4800 feff b901 003a 3bff 0aff  MThdH......:;...                                                                                                                              
00000010: d1ff 6aff ffff 03ff ffb5 b5b5 b5b5 ffff  ..j.............                                                                                                                              
00000020: ffff ffff ffb7 ffff fffa                 ..........