### PR TITLE
First implementation of running status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Alexandre Bique
+Copyright (c) 2016-2021 Alexandre Bique et al.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/midi-parser.h
+++ b/include/midi-parser.h
@@ -111,6 +111,8 @@ struct midi_sysex_event
 struct midi_parser
 {
   enum midi_parser_status state;
+  enum midi_status buffered_status;
+  int buffered_channel;
 
   /* input buffer */
   const uint8_t *in;


### PR DESCRIPTION
I needed running status since it seems to be commonly used in files found on the internet, see https://github.com/abique/midi-parser/issues/4, so I took a shot at an implementation. At least for the single file I tested it on, it does seem to fix most (all?) of the missing notes and unknown events.

Fixes #4, maybe