### PR TITLE
Fix status data lengths being wrong for some statuses, fix an assert

### DIFF
--- a/include/midi-parser.h
+++ b/include/midi-parser.h
@@ -112,7 +112,7 @@ struct midi_parser
 {
   enum midi_parser_status state;
   enum midi_status buffered_status;
-  int buffered_channel;
+  unsigned buffered_channel;
 
   /* input buffer */
   const uint8_t *in;

--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -172,13 +172,16 @@ midi_parse_channel_event(struct midi_parser *parser)
     if (parser->buffered_status == 0)
       return MIDI_PARSER_EOB;
     parser->midi.status  = parser->buffered_status;
+    int datalen = midi_event_datalen(parser->midi.status);
+    if (parser->size < datalen)
+      return MIDI_PARSER_EOB;
     parser->midi.channel = parser->buffered_channel;
-    parser->midi.param1  = parser->in[0];
-    parser->midi.param2  = parser->in[1];
+    parser->midi.param1  = (datalen > 0 ? parser->in[0] : 0);
+    parser->midi.param2  = (datalen > 1 ? parser->in[1] : 0);
 
-    parser->in         += 2;
-    parser->size       -= 2;
-    parser->track.size -= 2;
+    parser->in         += datalen;
+    parser->size       -= datalen;
+    parser->track.size -= datalen;
   } else {
     // Full event with its own status.
     if (parser->size < 3)


### PR DESCRIPTION
I noticed the file from #4 was still parsing incorrectly, and after some digging the problem was that some midi statuses have a different data length rather than the two bytes the parser always assumed, like Channel Pressure (`0xD`). While I didn't cover SysEx (`0xF0`) and System Common/Realtime messages which can still break things, these are probably less common in on-disk files rather than live streams which this library doesn't seem to be made for anyway. It is as it looks like good enough to fix parsing the file I tested. I also fixed an assert that was potentially accessing invalid memory, I think - at least it's not less correct than before now.