### PR TITLE
Fix parser->meta.bytes not being set for meta events

### DIFF
--- a/src/midi-parser.c
+++ b/src/midi-parser.c
@@ -224,6 +224,7 @@ midi_parse_meta_event(struct midi_parser *parser)
   if (parser->size < offset || parser->size - offset < parser->meta.length)
     return MIDI_PARSER_ERROR;
 
+  parser->meta.bytes = parser->in + offset;
   offset += parser->meta.length;
   parser->in += offset;
   parser->size -= offset;
@@ -234,6 +235,7 @@ midi_parse_meta_event(struct midi_parser *parser)
 static inline enum midi_parser_status
 midi_parse_event(struct midi_parser *parser)
 {
+  parser->meta.bytes = NULL;
   if (!midi_parse_vtime(parser))
     return MIDI_PARSER_EOB;
 


### PR DESCRIPTION
It appears that `parser->meta.bytes` was added so it would be pointing to the "payload" (the bytes that contain the meta event data, with the specified variable data length). However, no code so far actually set this pointer so that it was always `NULL`. This pull request fixes this and actually sets it.

If I misunderstood the intended use of `bytes` then please **do not merge** this, only if I actually guessed it correctly.