### PR TITLE
Fix cmake build broken by https://github.com/abique/midi-parser/pull/7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.o
-/demo
+*.a
+/midi-dump
 *.exe
+/cmake_install.cmake
+/Makefile
+/CMakeFiles
+CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ include_directories(include)
 add_library(midi-parser src/midi-parser.c)
 set_property(TARGET midi-parser PROPERTY C_STANDARD 99)
 
-add_executable(midi-dump src/midi-dump.c)
+add_executable(midi-dump example/midi-dump.c)
 set_property(TARGET midi-dump PROPERTY C_STANDARD 99)
 target_link_libraries(midi-dump midi-parser)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # midi-parser
 
 This repository contains a simple midi parser
@@ -13,7 +14,9 @@ due to its simple code and no use of file I/O.
 
 ## Use in your project
 
-To build midi-parser as part of your program,
+You can build midi-parser via `cmake . && make`.
+
+Alternatively, to build midi-parser as part of your program,
 add `src/midi-parser.c` to your project's
 object files, and the `include/` folder to your include path.
 (For Visual Studio, you'll find the required fields in your
@@ -28,10 +31,8 @@ $ gcc -o myprogram my_own_code.c path-to-midi-parser/src/midi-parser.c -Ipath-to
 
 ## Demo
 
-To build the `example/mini-dump.c` demo with gcc, do this:
+Running `cmake . && make` will also build the `example/mini-dump.c` demo
+as `midi-dump` executable.
 
-```
-$ gcc -o demo example/midi-dump.c src/midi-parser.c -Iinclude
-```
+You can then use `./midi-dump mymidifile.mid` on any midi file to test.
 
-You can then use `./demo mymidifile.mid` on any midi file to test.


### PR DESCRIPTION
With pull request https://github.com/abique/midi-parser/pull/7 I broke the cmake build file :scream: in part because I somehow failed to notice there's even a `CMakeLists.txt`, my apologies. This fixes it again, and adds info to the `README.md` about cmake.